### PR TITLE
Add local donor database editor and history display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,111 @@
-# CallTime
-Creating a proprietary website that I can use for call time for my candidates.
+# CallTime Desk
+
+CallTime Desk is an internal call-time workspace for campaign finance consultants.
+Create a dedicated donor queue for each client, pull profiles from Google Sheets or
+CSV exports, and log outcomes that remain private to the active campaign.
+
+## Highlights
+
+- **Multi-client switcher** keeps donor notes, pledges, and outcomes scoped to
+  the selected campaign.
+- **Dedicated donor database** capture full profiles (contact, biography,
+  company, industry, photo, and structured giving history) through the in-app
+  editor—no spreadsheet required.
+- **Google Sheet ingestion** still accepts either the `gviz` JSON feed or the
+  "Publish to web" CSV link from Sheets when you want to bulk-import records.
+- **Rich donor profiles** surface contact info, giving history, bios, and
+  optional tags directly in the call view.
+- **Structured outcomes** capture voicemail dates, follow-up commitments, and
+  contribution amounts with built-in prompts per status.
+- **Local storage persistence** saves call logs in the browser so each session
+  resumes where you left off.
+- **Demo workspace** loads sample clients and donors for quick evaluation.
+
+## Running the workspace locally
+
+This is a static web application. Start any HTTP server and open `index.html` in
+your browser:
+
+```bash
+python -m http.server 8000
+```
+
+Then navigate to <http://localhost:8000>.
+
+## Using the donor database
+
+Open the **Donor database** window from the global toolbar or the active client
+header to review and edit the profiles attached to the selected campaign.
+
+- Add donors with the **New donor** button, then fill in identity, contact,
+  professional, and biography fields. Suggested asks, last gift notes, and tags
+  help you organize follow-up plans.
+- Record detailed giving history by entering an election year, candidate, and
+  contribution amount. Each entry is grouped automatically by year, so you can
+  scan a donor’s past activity at a glance during call time.
+- Upload photo URLs to quickly differentiate supporters or to surface visual
+  cues for your candidate.
+- Use the JSON export button to create a portable backup of the current
+  campaign’s donor database.
+
+All changes save instantly to the local database for the active client. Notes
+and outcome logs remain private to each campaign, so overlapping prospects never
+share information between clients.
+
+## Connecting a Google Sheet
+
+1. Prepare a sheet with one row per donor. Helpful columns include:
+   - `Name`
+   - `Phone`
+   - `Email`
+   - `Ask` or `Ask Amount`
+   - `City`
+   - `Employer` or `Occupation`
+   - `Last Gift` (e.g., "$500 (2023)")
+   - `Bio` for background snippets
+   - `Notes` or `Priority`
+2. Publish the sheet so it is accessible:
+   - **Preferred:** `File → Share → Publish to web → Entire sheet → Web page`.
+     Copy the generated URL and replace the ending with `?format=csv`.
+   - **Alternative:** Use the `gviz` feed by copying the sheet ID and building
+     `https://docs.google.com/spreadsheets/d/<ID>/gviz/tq?tqx=out:json`.
+3. In CallTime Desk, add or edit a client and paste the published link into the
+   **Google Sheet link** field. Refresh the donors list to pull the latest
+   records.
+
+> **Tip:** If you need to keep separate worksheets per client, publish each
+> sheet individually and paste the unique link in the configuration form.
+
+## Data privacy
+
+- Outcomes (status, notes, follow-up dates, contribution amounts) are stored in
+  `localStorage` under the key `calltime:interactions:v1`.
+- Client configurations and the donor database live under
+  `calltime:database:v1`.
+- Clearing browser storage or switching browsers will remove this history. For a
+  shared office environment, pair the tool with a dedicated workstation profile
+  or export interactions periodically.
+
+## Built-in outcomes
+
+| Outcome                | Extra prompts                                 |
+| ---------------------- | --------------------------------------------- |
+| Not Contacted          | —                                             |
+| No Answer              | —                                             |
+| Left Voicemail         | Date voicemail was left                       |
+| Call Back Scheduled    | Follow-up date                                |
+| Committed to Donate    | Follow-up date, optional pledge amount        |
+| Received Contribution  | Contribution amount                           |
+| Do Not Call            | —                                             |
+
+Use the quick action buttons in the donor detail panel for one-click updates,
+then add notes and save. Statuses remain isolated to the client who is logged in
+so overlapping prospects never share information between campaigns.
+
+## Customizing
+
+- Update the interface styles via `styles.css`.
+- Extend donor parsing or add new outcome types in `app.js`.
+- Modify the layout and copy in `index.html` to match your firm’s brand.
+
+Pull requests and suggestions are welcome as you evolve your call-time process.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,1449 @@
+import { CallTimeDatabase, DATABASE_KEY } from "./database.js";
+
+const STORAGE_KEYS = {
+  interactions: "calltime:interactions:v1",
+};
+
+const STATUS_OPTIONS = [
+  "Not Contacted",
+  "No Answer",
+  "Left Voicemail",
+  "Call Back Scheduled",
+  "Committed to Donate",
+  "Received Contribution",
+  "Do Not Call",
+];
+
+const STATUS_VARIANT = {
+  "Not Contacted": "open",
+  "No Answer": "waiting",
+  "Left Voicemail": "waiting",
+  "Call Back Scheduled": "waiting",
+  "Committed to Donate": "waiting",
+  "Received Contribution": "won",
+  "Do Not Call": "closed",
+};
+
+const STATUS_DEFAULT_FIELDS = {
+  "Left Voicemail": [
+    { type: "date", name: "contactedOn", label: "Voicemail left", required: true },
+  ],
+  "Call Back Scheduled": [
+    { type: "date", name: "followUpOn", label: "Follow-up date", required: true },
+  ],
+  "Committed to Donate": [
+    { type: "date", name: "followUpOn", label: "Follow-up date", required: true },
+    {
+      type: "number",
+      name: "pledgeAmount",
+      label: "Pledge amount",
+      min: 0,
+      step: "25",
+      placeholder: "500",
+    },
+  ],
+  "Received Contribution": [
+    {
+      type: "number",
+      name: "contributionAmount",
+      label: "Contribution amount",
+      min: 0,
+      step: "25",
+      required: true,
+      placeholder: "1000",
+    },
+  ],
+};
+
+const db = new CallTimeDatabase();
+
+maybeMigrateLegacyClients();
+
+const DEMO_DATA = {
+  clients: [
+    {
+      id: "client-northdale",
+      label: "Avery for Northdale",
+      candidate: "Avery Johnson",
+      office: "State House District 14",
+      timezone: "America/New_York",
+      sheetUrl: "",
+      donors: [
+        {
+          id: "d1",
+          firstName: "Morgan",
+          lastName: "Patel",
+          name: "Morgan Patel",
+          phone: "(312) 555-0199",
+          email: "morgan@example.com",
+          ask: 750,
+          city: "Northdale",
+          employer: "Patel Strategies",
+          company: "Patel Strategies",
+          industry: "Consulting",
+          pictureUrl: "https://images.unsplash.com/photo-1524504388940-1d3f0ebdfa59?auto=format&fit=facearea&w=200&h=200&q=80",
+          lastGift: "$500 (2023)",
+          biography:
+            "Longtime supporter from the primary. Interested in workforce development and clean energy incentives.",
+          notes: "Prefers calls before noon Eastern.",
+          tags: "High Priority",
+          history: [
+            { year: 2023, candidate: "Avery for Northdale", amount: 500 },
+            { year: 2021, candidate: "Avery for Northdale", amount: 350 },
+          ],
+        },
+        {
+          id: "d2",
+          firstName: "Jordan",
+          lastName: "Smith",
+          name: "Jordan Smith",
+          phone: "(404) 555-2211",
+          email: "jordan@smithco.com",
+          ask: 1000,
+          city: "Atlanta",
+          employer: "SmithCo Logistics",
+          company: "SmithCo Logistics",
+          industry: "Logistics",
+          pictureUrl: "https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=facearea&w=200&h=200&q=80",
+          lastGift: "$1,000 (2022)",
+          biography:
+            "Member of the regional chamber. Wants concrete infrastructure updates. Joined host committee in 2021.",
+          notes: "Follow up with policy brief on port expansion.",
+          tags: "High Priority",
+          history: [
+            { year: 2022, candidate: "Avery for Northdale", amount: 1000 },
+            { year: 2020, candidate: "Northdale Forward PAC", amount: 750 },
+          ],
+        },
+        {
+          id: "d3",
+          firstName: "Amelia",
+          lastName: "Chen",
+          name: "Amelia Chen",
+          phone: "(470) 555-8844",
+          email: "amelia.chen@gmail.com",
+          ask: 500,
+          city: "Roswell",
+          employer: "Adobe",
+          company: "Adobe",
+          industry: "Technology",
+          pictureUrl: "https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=facearea&w=200&h=200&q=80",
+          lastGift: "New prospect",
+          biography:
+            "UX director and community volunteer. Board member at Northdale Literacy Fund.",
+          notes: "Was introduced by campaign chair last week.",
+          tags: "Warm",
+          history: [
+            { year: 2021, candidate: "Metro Literacy Fund", amount: 300 },
+          ],
+        },
+      ],
+    },
+    {
+      id: "client-riverbend",
+      label: "Committee to Elect Lucas",
+      candidate: "Lucas Martinez",
+      office: "City Council District 3",
+      timezone: "America/Chicago",
+      sheetUrl: "",
+      donors: [
+        {
+          id: "d4",
+          firstName: "Taylor",
+          lastName: "Nguyen",
+          name: "Taylor Nguyen",
+          phone: "(512) 555-0334",
+          email: "taylor@nguyenco.org",
+          ask: 350,
+          city: "Riverbend",
+          employer: "Nguyen Construction",
+          company: "Nguyen Construction",
+          industry: "Construction",
+          pictureUrl: "https://images.unsplash.com/photo-1508214751196-bcfd4ca60f91?auto=format&fit=facearea&w=200&h=200&q=80",
+          lastGift: "$250 (2021)",
+          biography:
+            "Supports walkable neighborhoods. Hosted Lucas in 2020 but sat out 2022 race.",
+          notes: "Mention new zoning reform endorsement.",
+          tags: "Reconnect",
+          history: [
+            { year: 2021, candidate: "Lucas Martinez for Council", amount: 250 },
+            { year: 2019, candidate: "Riverbend Main Street PAC", amount: 200 },
+          ],
+        },
+        {
+          id: "d5",
+          firstName: "Riley",
+          lastName: "Carter",
+          name: "Riley Carter",
+          phone: "(210) 555-8832",
+          email: "riley.carter@civicimpact.org",
+          ask: 500,
+          city: "Austin",
+          employer: "Civic Impact Alliance",
+          company: "Civic Impact Alliance",
+          industry: "Non-profit",
+          pictureUrl: "https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=facearea&w=200&h=200&q=80",
+          lastGift: "$500 (2023)",
+          biography:
+            "Non-profit director, enjoys policy deep dives. Values data and accountability.",
+          notes: "Send deck outlining summer organizing push.",
+          tags: "Renew",
+          history: [
+            { year: 2023, candidate: "Lucas Martinez for Council", amount: 500 },
+            { year: 2022, candidate: "Central City Education Fund", amount: 300 },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const state = {
+  clients: db.getClients(),
+  interactions: loadInteractions(),
+  activeClientId: null,
+  donors: [],
+  filteredDonors: [],
+  activeDonorId: null,
+  sessionActive: false,
+};
+
+const databaseState = {
+  donors: [],
+  filtered: [],
+  activeDonorId: null,
+};
+
+const elements = {
+  clientList: document.getElementById("client-list"),
+  emptyState: document.getElementById("empty-state"),
+  emptyCreate: document.getElementById("empty-create"),
+  emptyDemo: document.getElementById("empty-demo"),
+  clientDashboard: document.getElementById("client-dashboard"),
+  clientName: document.getElementById("client-name"),
+  clientMeta: document.getElementById("client-meta"),
+  donorItems: document.getElementById("donor-items"),
+  donorDetail: document.getElementById("donor-detail"),
+  donorSearch: document.getElementById("donor-search"),
+  statusFilter: document.getElementById("status-filter"),
+  refreshDonors: document.getElementById("refresh-donors"),
+  startSession: document.getElementById("start-session"),
+  manageClients: document.getElementById("manage-clients"),
+  manageDonors: document.getElementById("manage-donors"),
+  openDatabase: document.getElementById("open-database"),
+  addClient: document.getElementById("add-client"),
+  loadDemo: document.getElementById("load-demo"),
+  workspace: document.getElementById("workspace"),
+  clientDialog: document.getElementById("client-dialog"),
+  clientForm: document.getElementById("client-form"),
+  clientFormTitle: document.getElementById("client-form-title"),
+  emptyCreateButton: document.getElementById("empty-create"),
+  emptyDemoButton: document.getElementById("empty-demo"),
+  template: document.getElementById("donor-item-template"),
+  donorDatabase: document.getElementById("donor-database"),
+  closeDonorDatabase: document.getElementById("close-donor-database"),
+  exportDonorData: document.getElementById("export-donor-data"),
+  addDonor: document.getElementById("add-donor"),
+  donorDatabaseSearch: document.getElementById("donor-database-search"),
+  donorDatabaseItems: document.getElementById("donor-database-items"),
+  donorForm: document.getElementById("donor-form"),
+  donorPlaceholder: document.getElementById("donor-placeholder"),
+  historyYear: document.getElementById("history-year"),
+  historyCandidate: document.getElementById("history-candidate"),
+  historyAmount: document.getElementById("history-amount"),
+  addHistoryEntry: document.getElementById("add-history-entry"),
+  historyList: document.getElementById("history-list"),
+  deleteDonor: document.getElementById("delete-donor"),
+  donorUpdated: document.getElementById("donor-updated"),
+  databaseClientName: document.getElementById("database-client-name"),
+  databaseClientMeta: document.getElementById("database-client-meta"),
+};
+
+let clientFormMode = { mode: "create", id: null };
+
+init();
+
+function init() {
+  bindEvents();
+  renderStatusFilterOptions();
+  renderClients();
+  syncEmptyState();
+}
+
+function bindEvents() {
+  elements.addClient.addEventListener("click", () => openClientModal());
+  elements.manageClients.addEventListener("click", () => {
+    if (state.activeClientId) {
+      openClientModal(state.clients.find((c) => c.id === state.activeClientId));
+    } else {
+      openClientModal();
+    }
+  });
+  elements.loadDemo.addEventListener("click", loadDemoWorkspace);
+  elements.emptyCreateButton.addEventListener("click", () => openClientModal());
+  elements.emptyDemoButton.addEventListener("click", loadDemoWorkspace);
+  elements.clientDialog.addEventListener("close", handleClientFormClose);
+  elements.clientForm.addEventListener("submit", handleClientFormSubmit);
+  elements.donorSearch.addEventListener("input", handleSearch);
+  elements.statusFilter.addEventListener("change", applyFilters);
+  elements.refreshDonors.addEventListener("click", () => refreshDonorData());
+  elements.startSession.addEventListener("click", startCallSession);
+  elements.manageDonors.addEventListener("click", openDonorDatabase);
+  elements.openDatabase.addEventListener("click", openDonorDatabase);
+  elements.closeDonorDatabase.addEventListener("click", closeDonorDatabase);
+  elements.donorDatabase.addEventListener("cancel", (event) => {
+    event.preventDefault();
+    closeDonorDatabase();
+  });
+  elements.addDonor.addEventListener("click", handleCreateDonor);
+  elements.donorDatabaseSearch.addEventListener("input", handleDatabaseSearch);
+  elements.donorForm.addEventListener("submit", handleDonorFormSubmit);
+  elements.addHistoryEntry.addEventListener("click", handleAddHistoryEntry);
+  elements.historyList.addEventListener("click", handleHistoryListClick);
+  elements.deleteDonor.addEventListener("click", handleDeleteDonor);
+  elements.exportDonorData.addEventListener("click", exportDonorData);
+}
+
+function loadDemoWorkspace() {
+  DEMO_DATA.clients.forEach((demo) => {
+    const { donors = [], ...client } = demo;
+    db.upsertClient(client);
+    const currentDonors = db.getDonors(client.id);
+    if (!currentDonors.length && donors.length) {
+      db.replaceDonors(client.id, donors);
+    }
+  });
+  state.clients = db.getClients();
+  renderClients();
+  syncEmptyState();
+  if (!state.activeClientId && state.clients.length) {
+    selectClient(state.clients[0].id);
+  }
+}
+
+function renderStatusFilterOptions() {
+  STATUS_OPTIONS.forEach((status) => {
+    const option = document.createElement("option");
+    option.value = status;
+    option.textContent = status;
+    elements.statusFilter.append(option);
+  });
+}
+
+function renderClients() {
+  elements.clientList.innerHTML = "";
+  state.clients.forEach((client) => {
+    const item = document.createElement("li");
+    item.className = "client-item";
+    item.dataset.id = client.id;
+    if (client.id === state.activeClientId) {
+      item.classList.add("client-item--active");
+    }
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "client-item__button";
+    const clientTitle = escapeHtml(client.label || "Untitled client");
+    const clientMeta = escapeHtml(formatClientMeta(client));
+    button.innerHTML = `
+      <span class="client-item__title">${clientTitle}</span>
+      <span class="client-item__meta">${clientMeta}</span>
+    `;
+    button.addEventListener("click", () => {
+      if (state.activeClientId !== client.id) {
+        selectClient(client.id);
+      }
+    });
+
+    const actions = document.createElement("div");
+    actions.className = "client-item__actions";
+
+    const editButton = document.createElement("button");
+    editButton.type = "button";
+    editButton.innerHTML = "✎";
+    editButton.title = "Edit client";
+    editButton.addEventListener("click", (event) => {
+      event.stopPropagation();
+      openClientModal(client);
+    });
+
+    const deleteButton = document.createElement("button");
+    deleteButton.type = "button";
+    deleteButton.innerHTML = "✕";
+    deleteButton.title = "Remove client";
+    deleteButton.addEventListener("click", (event) => {
+      event.stopPropagation();
+      deleteClient(client.id);
+    });
+
+    actions.append(editButton, deleteButton);
+    item.append(button, actions);
+    elements.clientList.append(item);
+  });
+}
+
+function formatClientMeta(client) {
+  const parts = [];
+  if (client.candidate) parts.push(client.candidate);
+  if (client.office) parts.push(client.office);
+  return parts.join(" • ") || "Draft setup";
+}
+
+function selectClient(clientId) {
+  state.activeClientId = clientId;
+  state.activeDonorId = null;
+  state.sessionActive = false;
+  renderClients();
+  const client = state.clients.find((c) => c.id === clientId);
+  if (!client) return;
+  elements.clientName.textContent = client.label || "Untitled client";
+  const metaParts = [];
+  if (client.candidate) metaParts.push(client.candidate);
+  if (client.office) metaParts.push(client.office);
+  metaParts.push(client.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone);
+  elements.clientMeta.textContent = metaParts.filter(Boolean).join(" • ");
+  loadDonorData(client);
+  syncEmptyState();
+}
+
+function syncEmptyState() {
+  const hasClients = state.clients.length > 0;
+  if (!hasClients) {
+    elements.emptyState.classList.remove("hidden");
+    elements.clientDashboard.classList.add("hidden");
+  } else {
+    elements.emptyState.classList.add("hidden");
+    elements.clientDashboard.classList.toggle("hidden", !state.activeClientId);
+  }
+}
+
+function openClientModal(client) {
+  clientFormMode = client ? { mode: "edit", id: client.id } : { mode: "create", id: null };
+  elements.clientForm.reset();
+  if (client) {
+    elements.clientFormTitle.textContent = "Edit client";
+    elements.clientForm.elements.label.value = client.label || "";
+    elements.clientForm.elements.candidate.value = client.candidate || "";
+    elements.clientForm.elements.office.value = client.office || "";
+    elements.clientForm.elements.sheet.value = client.sheetUrl || "";
+    elements.clientForm.elements.timezone.value = client.timezone || "";
+  } else {
+    elements.clientFormTitle.textContent = "New client";
+  }
+  if (typeof elements.clientDialog.showModal === "function") {
+    elements.clientDialog.showModal();
+  } else {
+    elements.clientDialog.setAttribute("open", "");
+  }
+}
+
+function handleClientFormClose() {
+  clientFormMode = { mode: "create", id: null };
+}
+
+function handleClientFormSubmit(event) {
+  event.preventDefault();
+  const formData = new FormData(elements.clientForm);
+  const payload = Object.fromEntries(formData.entries());
+  const timezone = payload.timezone?.trim() || Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const clientRecord = {
+    id: clientFormMode.mode === "edit" ? clientFormMode.id : createId(payload.label),
+    label: payload.label?.trim(),
+    candidate: payload.candidate?.trim(),
+    office: payload.office?.trim(),
+    sheetUrl: payload.sheet?.trim(),
+    timezone,
+  };
+  db.upsertClient(clientRecord);
+  state.clients = db.getClients();
+  if (typeof elements.clientDialog.close === "function" && elements.clientDialog.open) {
+    elements.clientDialog.close();
+  } else {
+    elements.clientDialog.removeAttribute("open");
+  }
+  renderClients();
+  if (!state.activeClientId || clientFormMode.mode === "create") {
+    selectClient(clientRecord.id);
+  }
+  syncEmptyState();
+}
+
+function deleteClient(clientId) {
+  const client = state.clients.find((c) => c.id === clientId);
+  if (!client) return;
+  const confirmDelete = window.confirm(
+    `Remove ${client.label || "this client"}? Local notes for this client will also be removed.`,
+  );
+  if (!confirmDelete) return;
+  db.removeClient(clientId);
+  state.clients = db.getClients();
+  const interactions = loadInteractions();
+  delete interactions[clientId];
+  saveInteractions(interactions);
+  if (state.activeClientId === clientId) {
+    state.activeClientId = null;
+    state.donors = [];
+    state.filteredDonors = [];
+    state.activeDonorId = null;
+  }
+  state.interactions = interactions;
+  renderClients();
+  syncEmptyState();
+  if (state.clients.length) {
+    selectClient(state.clients[0].id);
+  }
+}
+
+async function loadDonorData(client) {
+  renderLoadingState();
+  try {
+    const previousDonorId = state.activeDonorId;
+    let donors = db.getDonors(client.id);
+    if (!donors.length && client.donors?.length) {
+      db.replaceDonors(client.id, client.donors);
+      donors = db.getDonors(client.id);
+    }
+    if (client.sheetUrl) {
+      const sheetDonors = await fetchDonorSheet(client.sheetUrl);
+      db.replaceDonors(client.id, sheetDonors);
+      donors = db.getDonors(client.id);
+    }
+    state.donors = donors.map((donor, index) => normalizeDonor(donor, index));
+    applyFilters();
+    if (previousDonorId && state.donors.some((donor) => donor.id === previousDonorId)) {
+      renderDonorDetail(previousDonorId);
+    } else if (state.donors.length) {
+      renderDonorDetail(state.donors[0].id);
+    } else {
+      renderEmptyDetail("No donor records found. Refresh after publishing your sheet.");
+    }
+  } catch (error) {
+    console.error(error);
+    renderEmptyDetail("We couldn't load donors. Check the sheet link and try again.");
+    elements.donorItems.innerHTML = `<li class="donor-item"><div class="donor-item__button">${escapeHtml(
+      error.message || "Failed to load donors",
+    )}</div></li>`;
+  }
+}
+
+function refreshDonorData() {
+  if (!state.activeClientId) return;
+  const client = state.clients.find((c) => c.id === state.activeClientId);
+  if (!client) return;
+  loadDonorData(client);
+}
+
+function renderLoadingState() {
+  elements.donorItems.innerHTML = "<li class=\"donor-item\"><div class=\"donor-item__button\">Loading donors…</div></li>";
+  renderEmptyDetail("Loading donor details");
+}
+
+function handleSearch() {
+  applyFilters();
+}
+
+function applyFilters() {
+  const query = elements.donorSearch.value?.toLowerCase().trim() || "";
+  const statusFilter = elements.statusFilter.value;
+  const interactions = state.interactions[state.activeClientId] || {};
+
+  state.filteredDonors = state.donors.filter((donor) => {
+    const haystack = [
+      donor.name,
+      donor.firstName,
+      donor.lastName,
+      donor.city,
+      donor.company,
+      donor.industry,
+      donor.employer,
+      donor.tags,
+      donor.notes,
+      donor.email,
+      donor.phone,
+      donor.biography,
+    ]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase();
+    const matchesQuery = !query || haystack.includes(query);
+    const donorStatus = interactions[donor.id]?.status || "Not Contacted";
+    const matchesStatus =
+      statusFilter === "all" || statusFilter.toLowerCase() === donorStatus.toLowerCase();
+    return matchesQuery && matchesStatus;
+  });
+
+  renderDonorList();
+}
+
+function renderDonorList() {
+  elements.donorItems.innerHTML = "";
+  if (!state.filteredDonors.length) {
+    elements.donorItems.innerHTML =
+      '<li class="donor-item"><div class="donor-item__button">No donors match your filters yet.</div></li>';
+    return;
+  }
+
+  const clientInteractions = state.interactions[state.activeClientId] || {};
+
+  state.filteredDonors.forEach((donor) => {
+    const clone = elements.template.content.firstElementChild.cloneNode(true);
+    const button = clone.querySelector(".donor-item__button");
+    button.addEventListener("click", () => renderDonorDetail(donor.id));
+    const status = clientInteractions[donor.id]?.status || "Not Contacted";
+    const variant = STATUS_VARIANT[status] || "open";
+    const statusLabel = `<span class="status-pill" data-variant="${variant}">${escapeHtml(status)}</span>`;
+    const metaParts = [];
+    if (donor.city) metaParts.push(escapeHtml(donor.city));
+    if (donor.company) metaParts.push(escapeHtml(donor.company));
+    else if (donor.employer) metaParts.push(escapeHtml(donor.employer));
+    if (donor.industry) metaParts.push(escapeHtml(donor.industry));
+    if (donor.ask) metaParts.push(escapeHtml(`Ask $${formatCurrency(donor.ask)}`));
+    button.innerHTML = `
+      <div class="donor-item__title">
+        <span class="donor-item__name">${escapeHtml(donor.name)}</span>
+        ${statusLabel}
+      </div>
+      <div class="donor-item__meta">${metaParts.join(" • ")}</div>
+    `;
+    if (state.activeDonorId === donor.id) {
+      clone.classList.add("donor-item--active");
+    }
+    elements.donorItems.append(clone);
+  });
+}
+
+function renderDonorDetail(donorId) {
+  const donor = state.donors.find((item) => item.id === donorId);
+  if (!donor) {
+    renderEmptyDetail("Select a donor to begin");
+    return;
+  }
+  state.activeDonorId = donorId;
+  renderDonorList();
+  const interaction = (state.interactions[state.activeClientId] || {})[donorId] || {
+    status: "Not Contacted",
+  };
+  const today = new Date().toISOString().slice(0, 10);
+  const identity = [donor.city, donor.company || donor.employer, donor.industry]
+    .filter(Boolean)
+    .map(escapeHtml)
+    .join(" • ");
+  const quickActions = STATUS_OPTIONS.map(
+    (status) => `
+      <button class="quick-action" type="button" data-status="${escapeAttribute(status)}">
+        ${escapeHtml(status)}
+      </button>
+    `,
+  ).join("");
+  const options = STATUS_OPTIONS.map(
+    (status) => `<option value="${escapeAttribute(status)}" ${
+      status === interaction.status ? "selected" : ""
+    }>${escapeHtml(status)}</option>`,
+  ).join("");
+  const biographySection = donor.biography
+    ? `<section class="donor-bio">${formatMultiline(donor.biography)}</section>`
+    : "";
+  const tagsSection = donor.tags
+    ? `<div class="donor-tags">${donor.tags
+        .split(/[,;]/)
+        .map((tag) => tag.trim())
+        .filter(Boolean)
+        .map((tag) => `<span class="donor-tag">${escapeHtml(tag)}</span>`)
+        .join("")}</div>`
+    : "";
+  const historySection = renderDonorHistorySection(donor.history || []);
+  const photo = donor.pictureUrl
+    ? `<figure class="donor-photo"><img src="${escapeAttribute(
+        donor.pictureUrl,
+      )}" alt="${escapeAttribute(donor.name)}" loading="lazy" /></figure>`
+    : "";
+  const updatedText = interaction.updatedAt
+    ? `Updated ${escapeHtml(formatRelativeTime(interaction.updatedAt))}`
+    : "No call logged yet";
+
+  elements.donorDetail.innerHTML = `
+    <article class="donor-profile" data-donor="${escapeAttribute(donor.id)}">
+      <header class="donor-detail__header">
+        <div class="donor-detail__headline">
+          <h2>${escapeHtml(donor.name)}</h2>
+          <div class="donor-detail__identity">${identity || ""}</div>
+          ${tagsSection}
+        </div>
+        ${photo}
+        <div class="donor-nav">
+          <button class="btn btn--ghost" data-nav="prev">Prev</button>
+          <button class="btn btn--ghost" data-nav="next">Next</button>
+        </div>
+      </header>
+
+      <section class="donor-contact">
+        ${renderContactCard("Mobile", donor.phone, donor.phone ? `tel:${donor.phone}` : "")}
+        ${renderContactCard("Email", donor.email, donor.email ? `mailto:${donor.email}` : "")}
+        ${renderContactCard("Ask", donor.ask ? `$${formatCurrency(donor.ask)}` : "—")}
+        ${renderContactCard("Last gift", donor.lastGift || "—")}
+        ${renderContactCard("Company", donor.company || donor.employer || "—")}
+        ${renderContactCard("Industry", donor.industry || "—")}
+      </section>
+
+      ${biographySection}
+      ${historySection}
+
+      <section class="donor-actions">
+        <div>
+          <h3>Quick outcomes</h3>
+          <div class="quick-actions">${quickActions}</div>
+        </div>
+        <form class="interaction-form" id="interaction-form">
+          <div class="form-row">
+            <label class="form-label" for="outcome-select">Outcome</label>
+            <select class="input select" id="outcome-select" name="status">
+              ${options}
+            </select>
+          </div>
+          <div class="dynamic-fields" id="dynamic-fields">
+            ${renderDynamicFields(interaction.status, interaction, today)}
+          </div>
+          <div class="form-row">
+            <label class="form-label" for="interaction-notes">Notes</label>
+            <textarea class="input textarea" id="interaction-notes" name="notes" placeholder="Conversation highlights, commitments, follow-ups">${escapeHtml(
+              interaction.notes || "",
+            )}</textarea>
+          </div>
+          <div class="interaction-save">
+            <div class="timestamp">${updatedText}</div>
+            <button class="btn btn--primary" type="submit">Save outcome</button>
+          </div>
+        </form>
+      </section>
+    </article>
+  `;
+
+  const interactionForm = document.getElementById("interaction-form");
+  const outcomeSelect = document.getElementById("outcome-select");
+  const dynamicFields = document.getElementById("dynamic-fields");
+
+  outcomeSelect.addEventListener("change", () => {
+    dynamicFields.innerHTML = renderDynamicFields(outcomeSelect.value, interaction, today);
+  });
+  elements.donorDetail
+    .querySelectorAll(".quick-action")
+    .forEach((button) =>
+      button.addEventListener("click", () => {
+        outcomeSelect.value = button.dataset.status;
+        dynamicFields.innerHTML = renderDynamicFields(outcomeSelect.value, interaction, today);
+      }),
+    );
+  interactionForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    saveInteraction(donor.id, new FormData(interactionForm));
+  });
+  elements.donorDetail
+    .querySelectorAll("[data-nav]")
+    .forEach((button) => button.addEventListener("click", handleDonorNavigation));
+}
+
+function renderDynamicFields(status, interaction, today) {
+  const fields = STATUS_DEFAULT_FIELDS[status];
+  if (!fields || !fields.length) {
+    return "";
+  }
+  const data = interaction || {};
+  return fields
+    .map((field) => {
+      const value = data[field.name] || (field.type === "date" ? today : "");
+      const attributes = [
+        'class="input"',
+        `type="${field.type}"`,
+        `name="${field.name}"`,
+        `id="${field.name}"`,
+        field.placeholder ? `placeholder="${escapeAttribute(field.placeholder)}"` : "",
+        field.min !== undefined ? `min="${escapeAttribute(field.min)}"` : "",
+        field.step ? `step="${escapeAttribute(field.step)}"` : "",
+        field.required ? "required" : "",
+        `value="${escapeAttribute(value ?? "")}"`,
+      ]
+        .filter(Boolean)
+        .join(" ");
+      return `
+        <div class="form-field">
+          <label class="form-label" for="${field.name}">${escapeHtml(field.label)}</label>
+          <input ${attributes} />
+        </div>
+      `;
+    })
+    .join("");
+}
+
+function renderContactCard(label, value, href) {
+  const safeLabel = escapeHtml(label);
+  if (!value || value === "—") {
+    return `
+      <div class="contact-card">
+        <span class="contact-card__label">${safeLabel}</span>
+        <span class="contact-card__value">—</span>
+      </div>
+    `;
+  }
+  const safeValue = escapeHtml(value);
+  const content = href
+    ? `<a href="${escapeAttribute(href)}" target="_blank" rel="noopener">${safeValue}</a>`
+    : safeValue;
+  return `
+    <div class="contact-card">
+      <span class="contact-card__label">${safeLabel}</span>
+      <span class="contact-card__value">${content}</span>
+    </div>
+  `;
+}
+
+function renderDonorHistorySection(history) {
+  if (!history.length) {
+    return `
+      <section class="donor-history" aria-labelledby="donor-history-title">
+        <div class="donor-history__title">
+          <h3 id="donor-history-title">Donor history</h3>
+          <p class="muted">Election-year contributions logged for this donor.</p>
+        </div>
+        <div class="history-empty">No contributions recorded yet.</div>
+      </section>
+    `;
+  }
+  const grouped = history.reduce((acc, entry) => {
+    const key = entry.year || "Other";
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(entry);
+    return acc;
+  }, {});
+  const years = Object.keys(grouped)
+    .map((value) => Number(value))
+    .sort((a, b) => b - a);
+  const sections = years
+    .map((year) => {
+      const entries = grouped[year];
+      const rows = entries
+        .map((entry) => {
+          const amountLabel =
+            entry.amount !== null && entry.amount !== undefined
+              ? `$${formatCurrency(entry.amount)}`
+              : "—";
+          return `
+            <li>
+              <span class="donor-history__candidate">${escapeHtml(entry.candidate || "")}</span>
+              <span class="donor-history__amount">${escapeHtml(amountLabel)}</span>
+            </li>
+          `;
+        })
+        .join("");
+      return `
+        <article class="donor-history__group">
+          <header>
+            <h4>${escapeHtml(String(year))}</h4>
+            <span class="donor-history__count">${entries.length} entr${entries.length === 1 ? "y" : "ies"}</span>
+          </header>
+          <ul>${rows}</ul>
+        </article>
+      `;
+    })
+    .join("");
+  return `
+    <section class="donor-history" aria-labelledby="donor-history-title">
+      <div class="donor-history__title">
+        <h3 id="donor-history-title">Donor history</h3>
+        <p class="muted">Election-year contributions logged for this donor.</p>
+      </div>
+      ${sections}
+    </section>
+  `;
+}
+
+function renderEmptyDetail(message) {
+  elements.donorDetail.innerHTML = `<div class="donor-detail__placeholder">${escapeHtml(message)}</div>`;
+}
+
+function handleDonorNavigation(event) {
+  const direction = event.currentTarget.dataset.nav;
+  if (!direction) return;
+  const currentIndex = state.filteredDonors.findIndex((donor) => donor.id === state.activeDonorId);
+  if (currentIndex === -1) return;
+  const nextIndex = direction === "next" ? currentIndex + 1 : currentIndex - 1;
+  const nextDonor = state.filteredDonors[nextIndex];
+  if (nextDonor) {
+    renderDonorDetail(nextDonor.id);
+  }
+}
+
+function saveInteraction(donorId, formData) {
+  const data = Object.fromEntries(formData.entries());
+  const status = data.status || "Not Contacted";
+  const record = {
+    status,
+    notes: data.notes?.trim() || "",
+    updatedAt: new Date().toISOString(),
+  };
+  if (STATUS_DEFAULT_FIELDS[status]) {
+    STATUS_DEFAULT_FIELDS[status].forEach((field) => {
+      if (data[field.name]) {
+        record[field.name] = data[field.name];
+      }
+    });
+  }
+  if (!state.interactions[state.activeClientId]) {
+    state.interactions[state.activeClientId] = {};
+  }
+  state.interactions[state.activeClientId][donorId] = record;
+  saveInteractions(state.interactions);
+  renderDonorList();
+  renderDonorDetail(donorId);
+}
+
+function startCallSession() {
+  state.sessionActive = true;
+  const interactions = state.interactions[state.activeClientId] || {};
+  const nextDonor = state.filteredDonors.find((donor) => {
+    const status = interactions[donor.id]?.status || "Not Contacted";
+    return status === "Not Contacted" || status === "No Answer" || status === "Left Voicemail";
+  });
+  if (nextDonor) {
+    renderDonorDetail(nextDonor.id);
+  }
+  elements.workspace.focus();
+}
+
+function openDonorDatabase() {
+  if (!state.activeClientId) {
+    window.alert("Select a client to manage donor records.");
+    return;
+  }
+  const client = state.clients.find((c) => c.id === state.activeClientId);
+  if (!client) return;
+  syncDatabaseState();
+  elements.databaseClientName.textContent = client.label || "Untitled client";
+  elements.databaseClientMeta.textContent = [
+    client.candidate,
+    client.office,
+    client.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
+  ]
+    .filter(Boolean)
+    .join(" • ");
+  renderDatabaseList();
+  if (!databaseState.activeDonorId && databaseState.filtered.length) {
+    databaseState.activeDonorId = databaseState.filtered[0].id;
+  }
+  renderDatabaseEditor();
+  if (typeof elements.donorDatabase.showModal === "function") {
+    elements.donorDatabase.showModal();
+  } else {
+    elements.donorDatabase.setAttribute("open", "");
+  }
+}
+
+function closeDonorDatabase() {
+  if (typeof elements.donorDatabase.close === "function" && elements.donorDatabase.open) {
+    elements.donorDatabase.close();
+  } else {
+    elements.donorDatabase.removeAttribute("open");
+  }
+}
+
+function handleCreateDonor() {
+  if (!state.activeClientId) return;
+  const donor = db.createDonor(state.activeClientId, { firstName: "New", lastName: "Donor" });
+  databaseState.activeDonorId = donor.id;
+  state.activeDonorId = donor.id;
+  elements.donorDatabaseSearch.value = "";
+  syncDatabaseState();
+  renderDatabaseList();
+  renderDatabaseEditor();
+  loadDonorData(state.clients.find((c) => c.id === state.activeClientId));
+}
+
+function handleDatabaseSearch() {
+  syncDatabaseState();
+  renderDatabaseList();
+  renderDatabaseEditor();
+}
+
+function handleDonorSelection(donorId) {
+  databaseState.activeDonorId = donorId;
+  renderDatabaseList();
+  renderDatabaseEditor();
+}
+
+function handleDonorFormSubmit(event) {
+  event.preventDefault();
+  if (!state.activeClientId || !databaseState.activeDonorId) return;
+  const formData = new FormData(elements.donorForm);
+  const payload = Object.fromEntries(formData.entries());
+  db.updateDonor(state.activeClientId, databaseState.activeDonorId, {
+    firstName: payload.firstName?.trim(),
+    lastName: payload.lastName?.trim(),
+    email: payload.email?.trim(),
+    phone: payload.phone?.trim(),
+    company: payload.company?.trim(),
+    industry: payload.industry?.trim(),
+    city: payload.city?.trim(),
+    tags: payload.tags?.trim(),
+    pictureUrl: payload.pictureUrl?.trim(),
+    ask: payload.ask,
+    lastGift: payload.lastGift?.trim(),
+    donorNotes: payload.notes?.trim(),
+    biography: payload.biography?.trim(),
+  });
+  syncDatabaseState();
+  renderDatabaseList();
+  renderDatabaseEditor();
+  loadDonorData(state.clients.find((c) => c.id === state.activeClientId));
+  elements.donorUpdated.textContent = `Saved ${new Date().toLocaleString()}`;
+}
+
+function handleAddHistoryEntry() {
+  if (!state.activeClientId || !databaseState.activeDonorId) return;
+  const year = Number(elements.historyYear.value);
+  const candidate = elements.historyCandidate.value.trim();
+  const amountValue = elements.historyAmount.value;
+  const amount = amountValue === "" ? null : Number(amountValue);
+  if (!candidate) {
+    window.alert("Add a candidate name before saving the contribution.");
+    return;
+  }
+  db.addContribution(state.activeClientId, databaseState.activeDonorId, {
+    year: Number.isNaN(year) ? undefined : year,
+    candidate,
+    amount,
+  });
+  elements.historyYear.value = "";
+  elements.historyCandidate.value = "";
+  elements.historyAmount.value = "";
+  syncDatabaseState();
+  renderDatabaseList();
+  renderDatabaseEditor();
+  loadDonorData(state.clients.find((c) => c.id === state.activeClientId));
+  elements.donorUpdated.textContent = `Logged contribution ${new Date().toLocaleTimeString()}`;
+}
+
+function handleHistoryListClick(event) {
+  const button = event.target.closest("button[data-history]");
+  if (!button || !state.activeClientId || !databaseState.activeDonorId) return;
+  db.removeContribution(state.activeClientId, databaseState.activeDonorId, button.dataset.history);
+  syncDatabaseState();
+  renderDatabaseEditor();
+  loadDonorData(state.clients.find((c) => c.id === state.activeClientId));
+  elements.donorUpdated.textContent = `Removed contribution ${new Date().toLocaleTimeString()}`;
+}
+
+function handleDeleteDonor() {
+  if (!state.activeClientId || !databaseState.activeDonorId) return;
+  const donor = databaseState.donors.find((item) => item.id === databaseState.activeDonorId);
+  const confirmDelete = window.confirm(
+    `Remove ${donor?.name || "this donor"} from the database? This can't be undone.`,
+  );
+  if (!confirmDelete) return;
+  db.deleteDonor(state.activeClientId, databaseState.activeDonorId);
+  databaseState.activeDonorId = null;
+  syncDatabaseState();
+  renderDatabaseList();
+  renderDatabaseEditor();
+  loadDonorData(state.clients.find((c) => c.id === state.activeClientId));
+  elements.donorUpdated.textContent = `Deleted donor ${new Date().toLocaleTimeString()}`;
+}
+
+function exportDonorData() {
+  if (!state.activeClientId) return;
+  const donors = db.getDonors(state.activeClientId);
+  const blob = new Blob([JSON.stringify(donors, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  const client = state.clients.find((c) => c.id === state.activeClientId);
+  const filename = `${(client?.label || "calltime").replace(/[^a-z0-9]+/gi, "-")}-donors.json`;
+  link.download = filename.toLowerCase();
+  document.body.append(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+function syncDatabaseState() {
+  if (!state.activeClientId) {
+    databaseState.donors = [];
+    databaseState.filtered = [];
+    return;
+  }
+  databaseState.donors = db.getDonors(state.activeClientId);
+  const query = elements.donorDatabaseSearch.value?.toLowerCase().trim() || "";
+  databaseState.filtered = databaseState.donors.filter((donor) => {
+    if (!query) return true;
+    const haystack = [
+      donor.name,
+      donor.firstName,
+      donor.lastName,
+      donor.company,
+      donor.industry,
+      donor.email,
+      donor.city,
+      donor.tags,
+    ]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase();
+    return haystack.includes(query);
+  });
+  if (
+    databaseState.activeDonorId &&
+    !databaseState.filtered.some((donor) => donor.id === databaseState.activeDonorId)
+  ) {
+    databaseState.activeDonorId = databaseState.filtered[0]?.id || null;
+  } else if (!databaseState.activeDonorId && databaseState.filtered.length) {
+    databaseState.activeDonorId = databaseState.filtered[0].id;
+  }
+}
+
+function renderDatabaseList() {
+  elements.donorDatabaseItems.innerHTML = "";
+  if (!databaseState.filtered.length) {
+    const item = document.createElement("li");
+    item.className = "database-panel__item";
+    const button = document.createElement("button");
+    button.type = "button";
+    button.disabled = true;
+    button.innerHTML = `
+      <span class="database-panel__item-title">No donors saved yet</span>
+      <span class="database-panel__item-meta">Add a donor to begin tracking calls.</span>
+    `;
+    item.append(button);
+    elements.donorDatabaseItems.append(item);
+    return;
+  }
+  databaseState.filtered.forEach((donor) => {
+    const item = document.createElement("li");
+    item.className = "database-panel__item";
+    if (databaseState.activeDonorId === donor.id) {
+      item.classList.add("database-panel__item--active");
+    }
+    const button = document.createElement("button");
+    button.type = "button";
+    const meta = [donor.company, donor.industry, donor.city].filter(Boolean).join(" • ") || donor.email || "";
+    button.innerHTML = `
+      <span class="database-panel__item-title">${escapeHtml(donor.name)}</span>
+      <span class="database-panel__item-meta">${escapeHtml(meta)}</span>
+    `;
+    button.addEventListener("click", () => handleDonorSelection(donor.id));
+    item.append(button);
+    elements.donorDatabaseItems.append(item);
+  });
+}
+
+function renderDatabaseEditor() {
+  const donor = databaseState.donors.find((item) => item.id === databaseState.activeDonorId);
+  const hasDonor = Boolean(donor);
+  elements.donorForm.classList.toggle("hidden", !hasDonor);
+  elements.donorPlaceholder?.classList.toggle("hidden", hasDonor);
+  if (!hasDonor) {
+    elements.donorForm.reset();
+    elements.donorUpdated.textContent = "";
+    elements.historyList.innerHTML = "";
+    return;
+  }
+  elements.donorForm.scrollTop = 0;
+  elements.donorForm.elements.firstName.value = donor.firstName || "";
+  elements.donorForm.elements.lastName.value = donor.lastName || "";
+  elements.donorForm.elements.email.value = donor.email || "";
+  elements.donorForm.elements.phone.value = donor.phone || "";
+  elements.donorForm.elements.company.value = donor.company || "";
+  elements.donorForm.elements.industry.value = donor.industry || "";
+  elements.donorForm.elements.city.value = donor.city || "";
+  elements.donorForm.elements.tags.value = donor.tags || "";
+  elements.donorForm.elements.pictureUrl.value = donor.pictureUrl || "";
+  elements.donorForm.elements.ask.value = donor.ask ?? "";
+  elements.donorForm.elements.lastGift.value = donor.lastGift || "";
+  elements.donorForm.elements.notes.value = donor.notes || "";
+  elements.donorForm.elements.biography.value = donor.biography || "";
+  elements.donorUpdated.textContent = "";
+  renderHistoryList(donor.history || []);
+}
+
+function renderHistoryList(history) {
+  if (!history.length) {
+    elements.historyList.innerHTML = '<div class="history-empty">No contributions recorded yet.</div>';
+    return;
+  }
+  const groups = history.reduce((acc, entry) => {
+    const key = entry.year || "Other";
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(entry);
+    return acc;
+  }, {});
+  const years = Object.keys(groups)
+    .map((value) => Number(value))
+    .sort((a, b) => b - a);
+  elements.historyList.innerHTML = years
+    .map((year) => {
+      const entries = groups[year];
+      const rows = entries
+        .map(
+          (entry) => `
+            <tr>
+              <td>${escapeHtml(entry.candidate || "")}</td>
+              <td>${entry.amount !== null && entry.amount !== undefined ? `$${formatCurrency(entry.amount)}` : "—"}</td>
+              <td class="history-table__actions"><button type="button" class="history-delete" data-history="${escapeAttribute(
+                entry.id,
+              )}">Remove</button></td>
+            </tr>
+          `,
+        )
+        .join("");
+      return `
+        <article class="history-group">
+          <div class="history-group__title">
+            <span>${escapeHtml(String(year))}</span>
+            <span>${entries.length} entr${entries.length === 1 ? "y" : "ies"}</span>
+          </div>
+          <table class="history-table">
+            <thead>
+              <tr><th>Candidate</th><th>Amount</th><th></th></tr>
+            </thead>
+            <tbody>${rows}</tbody>
+          </table>
+        </article>
+      `;
+    })
+    .join("");
+}
+
+function fetchDonorSheet(url) {
+  return fetch(url)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error("Unable to fetch sheet. Make sure it is published and public.");
+      }
+      return response.text();
+    })
+    .then((text) => {
+      if (text.trim().startsWith("google.visualization")) {
+        return parseGviz(text);
+      }
+      if (text.includes(",")) {
+        return parseCsv(text);
+      }
+      throw new Error("Unsupported sheet format. Use the gviz JSON or CSV publish link.");
+    });
+}
+
+function parseGviz(text) {
+  const json = JSON.parse(text.replace(/^.*?\(/, "").replace(/\);?$/, ""));
+  const cols = json.table.cols.map((col) => col.label || col.id);
+  return json.table.rows
+    .map((row) => row.c)
+    .map((cells) => {
+      const entry = {};
+      cells.forEach((cell, index) => {
+        entry[cols[index]] = cell && cell.v !== null ? cell.v : "";
+      });
+      return entry;
+    });
+}
+
+function parseCsv(text) {
+  const rows = [];
+  let current = [];
+  let field = "";
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i];
+    if (char === '"') {
+      if (inQuotes && text[i + 1] === '"') {
+        field += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === "," && !inQuotes) {
+      current.push(field);
+      field = "";
+    } else if ((char === "\n" || char === "\r") && !inQuotes) {
+      if (field || current.length) {
+        current.push(field);
+        rows.push(current);
+        current = [];
+        field = "";
+      }
+      if (char === "\r" && text[i + 1] === "\n") i += 1;
+    } else {
+      field += char;
+    }
+  }
+  if (field || current.length) {
+    current.push(field);
+    rows.push(current);
+  }
+  if (!rows.length) return [];
+  const headers = rows.shift().map((header) => header.trim());
+  return rows
+    .filter((row) => row.some((cell) => cell.trim() !== ""))
+    .map((row) => {
+      const entry = {};
+      headers.forEach((header, index) => {
+        entry[header] = row[index] ? row[index].trim() : "";
+      });
+      return entry;
+    });
+}
+
+function normalizeDonor(raw, index) {
+  const safe = typeof raw === "object" ? { ...raw } : {};
+  const id = safe.id || createId(`${safe.Name || safe.name || safe.Email || index}`);
+  const askValue = parseNumber(safe.Ask || safe.ask || safe["Ask Amount"]);
+  const firstName = safe.firstName || safe.FirstName || safe["First Name"] || "";
+  const lastName = safe.lastName || safe.LastName || safe["Last Name"] || "";
+  const company = safe.company || safe.Company || safe.employer || safe.Employer || "";
+  const industry = safe.industry || safe.Industry || safe.Sector || "";
+  const pictureUrl = safe.pictureUrl || safe.Picture || safe.photo || safe.Photo || "";
+  const history = Array.isArray(safe.history)
+    ? safe.history.map((item) => normalizeHistoryEntry(item)).filter(Boolean)
+    : [];
+  const derivedName = `${firstName} ${lastName}`.trim();
+  return {
+    id,
+    name:
+      safe.Name || safe.name || safe["Full Name"] || safe["Donor"] || derivedName || "Unknown Donor",
+    firstName: firstName.trim(),
+    lastName: lastName.trim(),
+    phone: safe.Phone || safe.phone || safe["Phone Number"] || safe["Cell"] || "",
+    email: safe.Email || safe.email || safe["Email Address"] || "",
+    ask: askValue,
+    city: safe.City || safe.city || safe["Mailing City"] || safe["City, State"] || "",
+    employer:
+      safe.Employer || safe.employer || safe["Occupation"] || safe["Company"] || safe["Employer/Occupation"] || company || "",
+    company: company.trim(),
+    industry: industry.trim(),
+    lastGift: safe["Last Gift"] || safe["Last Donation"] || safe["Giving History"] || safe["History"] || "",
+    biography: safe.Bio || safe.biography || safe["Profile"] || safe["Notes Bio"] || "",
+    notes: safe.Notes || safe.notes || "",
+    tags: safe.Priority || safe.priority || safe["Tag"] || "",
+    pictureUrl: pictureUrl.trim(),
+    history,
+  };
+}
+
+function formatCurrency(value) {
+  if (value === null || value === undefined || Number.isNaN(Number(value))) return "";
+  return Number(value).toLocaleString(undefined, { maximumFractionDigits: 0 });
+}
+
+function parseNumber(value) {
+  if (value === null || value === undefined || value === "") return null;
+  const numeric = Number(String(value).replace(/[^0-9.]/g, ""));
+  return Number.isNaN(numeric) ? null : numeric;
+}
+
+function normalizeHistoryEntry(entry) {
+  if (!entry) return null;
+  const source = typeof entry === "object" ? { ...entry } : {};
+  const yearValue = Number(source.year ?? source.Year ?? source["Election Year"]);
+  const candidate = (source.candidate || source.Candidate || "").trim();
+  const amount = parseNumber(source.amount ?? source.Amount ?? source["Contribution"]);
+  const id = source.id || createId(`${yearValue || ""}-${candidate || ""}-${amount ?? ""}`);
+  const year = Number.isNaN(yearValue) ? new Date().getFullYear() : yearValue;
+  return {
+    id,
+    year,
+    candidate,
+    amount,
+  };
+}
+
+function escapeHtml(value) {
+  if (value === null || value === undefined) return "";
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function escapeAttribute(value) {
+  return escapeHtml(value);
+}
+
+function formatMultiline(value) {
+  return escapeHtml(value).replace(/\r?\n/g, "<br />");
+}
+
+function formatRelativeTime(timestamp) {
+  const updated = new Date(timestamp);
+  const now = new Date();
+  const diff = Math.round((now - updated) / (1000 * 60));
+  if (diff < 1) return "Just now";
+  if (diff < 60) return `${diff} min ago`;
+  const hours = Math.round(diff / 60);
+  if (hours < 24) return `${hours} hr ago`;
+  const days = Math.round(hours / 24);
+  return `${days} day${days === 1 ? "" : "s"} ago`;
+}
+
+function createId(value = "") {
+  const cleaned = value
+    .toString()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 32);
+  if (cleaned) return cleaned;
+  const fallback =
+    typeof crypto !== "undefined" && crypto.randomUUID
+      ? crypto.randomUUID()
+      : Math.random().toString(36).slice(2, 10);
+  return `id-${fallback}`;
+}
+
+function loadInteractions() {
+  try {
+    const value = localStorage.getItem(STORAGE_KEYS.interactions);
+    if (!value) return {};
+    return JSON.parse(value);
+  } catch (error) {
+    console.error("Failed to parse interactions", error);
+    return {};
+  }
+}
+
+function saveInteractions(interactions) {
+  localStorage.setItem(STORAGE_KEYS.interactions, JSON.stringify(interactions));
+}
+
+function maybeMigrateLegacyClients() {
+  try {
+    const legacy = localStorage.getItem("calltime:clients:v2");
+    if (!legacy) return;
+    if (db.getClients().length) return;
+    const parsed = JSON.parse(legacy);
+    if (!Array.isArray(parsed)) return;
+    parsed.forEach((client) => {
+      if (!client || !client.id) return;
+      const { donors = [], ...rest } = client;
+      db.upsertClient(rest);
+      if (donors.length) {
+        db.replaceDonors(client.id, donors);
+      }
+    });
+    localStorage.removeItem("calltime:clients:v2");
+  } catch (error) {
+    console.error("Failed to migrate legacy clients", error);
+  }
+}
+
+window.addEventListener("storage", (event) => {
+  if (event.key && ![DATABASE_KEY, STORAGE_KEYS.interactions].includes(event.key)) {
+    return;
+  }
+  db.reload();
+  state.clients = db.getClients();
+  state.interactions = loadInteractions();
+  renderClients();
+  if (state.activeClientId) {
+    selectClient(state.activeClientId);
+  } else {
+    syncEmptyState();
+  }
+});

--- a/database.js
+++ b/database.js
@@ -1,0 +1,246 @@
+export const DATABASE_KEY = "calltime:database:v1";
+
+export class CallTimeDatabase {
+  constructor(storage = window.localStorage) {
+    this.storage = storage;
+    this.data = this.load();
+  }
+
+  load() {
+    try {
+      const raw = this.storage.getItem(DATABASE_KEY);
+      if (!raw) {
+        return { clients: [], donors: {} };
+      }
+      const parsed = JSON.parse(raw);
+      return {
+        clients: Array.isArray(parsed.clients) ? parsed.clients : [],
+        donors: typeof parsed.donors === "object" && parsed.donors !== null ? parsed.donors : {},
+      };
+    } catch (error) {
+      console.error("Failed to parse database", error);
+      return { clients: [], donors: {} };
+    }
+  }
+
+  persist() {
+    this.storage.setItem(DATABASE_KEY, JSON.stringify(this.data));
+  }
+
+  reload() {
+    this.data = this.load();
+    return this.getClients();
+  }
+
+  getClients() {
+    return this.data.clients.map((client) => ({ ...client }));
+  }
+
+  getClient(clientId) {
+    return this.data.clients.find((client) => client.id === clientId) || null;
+  }
+
+  upsertClient(record) {
+    if (!record || !record.id) {
+      throw new Error("Client records must include an id");
+    }
+    const index = this.data.clients.findIndex((client) => client.id === record.id);
+    if (index === -1) {
+      this.data.clients.push({ ...record });
+    } else {
+      this.data.clients[index] = { ...this.data.clients[index], ...record };
+    }
+    if (!this.data.donors[record.id]) {
+      this.data.donors[record.id] = [];
+    }
+    this.persist();
+    return this.getClient(record.id);
+  }
+
+  removeClient(clientId) {
+    this.data.clients = this.data.clients.filter((client) => client.id !== clientId);
+    if (this.data.donors[clientId]) {
+      delete this.data.donors[clientId];
+    }
+    this.persist();
+  }
+
+  getDonors(clientId) {
+    const donors = this.data.donors[clientId] || [];
+    return donors.map((donor) => this.cloneDonor(donor));
+  }
+
+  replaceDonors(clientId, donors) {
+    this.ensureClientDonorArray(clientId);
+    this.data.donors[clientId] = donors.map((donor) => this.normalizeDonor(donor));
+    this.persist();
+    return this.getDonors(clientId);
+  }
+
+  createDonor(clientId, initial = {}) {
+    this.ensureClientDonorArray(clientId);
+    const donor = this.normalizeDonor({ ...initial, id: initial.id || this.createDonorId(initial) });
+    this.data.donors[clientId].push(donor);
+    this.persist();
+    return this.cloneDonor(donor);
+  }
+
+  updateDonor(clientId, donorId, updates) {
+    this.ensureClientDonorArray(clientId);
+    const donors = this.data.donors[clientId];
+    const index = donors.findIndex((donor) => donor.id === donorId);
+    if (index === -1) {
+      throw new Error("Donor not found");
+    }
+    donors[index] = this.normalizeDonor({ ...donors[index], ...updates, id: donorId });
+    this.persist();
+    return this.cloneDonor(donors[index]);
+  }
+
+  deleteDonor(clientId, donorId) {
+    this.ensureClientDonorArray(clientId);
+    this.data.donors[clientId] = this.data.donors[clientId].filter((donor) => donor.id !== donorId);
+    this.persist();
+  }
+
+  addContribution(clientId, donorId, entry) {
+    this.ensureClientDonorArray(clientId);
+    const donors = this.data.donors[clientId];
+    const donor = donors.find((item) => item.id === donorId);
+    if (!donor) {
+      throw new Error("Donor not found");
+    }
+    const contribution = this.normalizeContribution({ ...entry, id: entry.id || this.createContributionId(entry) });
+    donor.history.push(contribution);
+    donor.history.sort((a, b) => {
+      if (a.year === b.year) {
+        return a.candidate.localeCompare(b.candidate);
+      }
+      return b.year - a.year;
+    });
+    this.persist();
+    return contribution;
+  }
+
+  removeContribution(clientId, donorId, contributionId) {
+    this.ensureClientDonorArray(clientId);
+    const donors = this.data.donors[clientId];
+    const donor = donors.find((item) => item.id === donorId);
+    if (!donor) {
+      throw new Error("Donor not found");
+    }
+    donor.history = donor.history.filter((item) => item.id !== contributionId);
+    this.persist();
+  }
+
+  ensureClientDonorArray(clientId) {
+    if (!this.data.donors[clientId]) {
+      this.data.donors[clientId] = [];
+    }
+  }
+
+  createDonorId(initial = {}) {
+    const base = [initial.firstName, initial.lastName, initial.email]
+      .filter(Boolean)
+      .join("-");
+    return CallTimeDatabase.createId(base || `donor-${Date.now()}`);
+  }
+
+  createContributionId(entry = {}) {
+    const base = [entry.year, entry.candidate, entry.amount]
+      .filter(Boolean)
+      .join("-");
+    return CallTimeDatabase.createId(base || `contribution-${Date.now()}`);
+  }
+
+  normalizeDonor(raw) {
+    const source = typeof raw === "object" && raw !== null ? raw : {};
+    const firstName = source.firstName || source.FirstName || source["First Name"] || "";
+    const lastName = source.lastName || source.LastName || source["Last Name"] || "";
+    const company = source.company || source.Company || source.employer || source.Employer || "";
+    const industry = source.industry || source.Industry || source.Sector || "";
+    const biography = source.biography || source.Biography || source.bio || source.Bio || "";
+    const pictureUrl = source.pictureUrl || source.photo || source.Picture || source.Photo || "";
+    const ask = this.parseNumber(source.ask ?? source.Ask ?? source["Ask Amount"]);
+    const history = Array.isArray(source.history)
+      ? source.history.map((item) => this.normalizeContribution(item)).filter(Boolean)
+      : [];
+    history.sort((a, b) => {
+      if (a.year === b.year) {
+        return a.candidate.localeCompare(b.candidate);
+      }
+      return (b.year || 0) - (a.year || 0);
+    });
+
+    const donor = {
+      id: source.id || this.createDonorId(source),
+      firstName: firstName.trim(),
+      lastName: lastName.trim(),
+      company: company.trim(),
+      industry: industry.trim(),
+      phone: (source.phone || source.Phone || "").trim(),
+      email: (source.email || source.Email || "").trim(),
+      biography: biography.trim(),
+      pictureUrl: pictureUrl.trim(),
+      donorNotes: (source.donorNotes || source.notes || source.Notes || "").trim(),
+      ask,
+      city: (source.city || source.City || source["Mailing City"] || "").trim(),
+      tags: (source.tags || source.Tags || source.Priority || "").trim(),
+      lastGift: (source.lastGift || source["Last Gift"] || source["Giving History"] || "").trim(),
+      history,
+    };
+
+    donor.name = this.buildDisplayName(donor, source.name || source.Name || source["Full Name"]);
+    donor.employer = donor.company;
+    donor.notes = donor.donorNotes;
+    return donor;
+  }
+
+  normalizeContribution(raw) {
+    if (!raw) return null;
+    const source = typeof raw === "object" ? raw : {};
+    const yearValue = Number(source.year ?? source.Year ?? source["Election Year"]);
+    const candidate = (source.candidate || source.Candidate || "").trim();
+    const amount = this.parseNumber(source.amount ?? source.Amount ?? source["Contribution"]);
+    if (!candidate && Number.isNaN(yearValue) && (amount === null || Number.isNaN(amount))) {
+      return null;
+    }
+    const year = Number.isNaN(yearValue) ? new Date().getFullYear() : yearValue;
+    return {
+      id: source.id || this.createContributionId({ year, candidate, amount }),
+      year,
+      candidate,
+      amount,
+    };
+  }
+
+  parseNumber(value) {
+    if (value === null || value === undefined || value === "") return null;
+    const numeric = Number(String(value).replace(/[^0-9.]/g, ""));
+    return Number.isNaN(numeric) ? null : numeric;
+  }
+
+  buildDisplayName(donor, fallback) {
+    const base = `${donor.firstName} ${donor.lastName}`.trim();
+    const fromFallback = fallback ? String(fallback).trim() : "";
+    return base || fromFallback || donor.email || "New Donor";
+  }
+
+  cloneDonor(donor) {
+    return JSON.parse(JSON.stringify(donor));
+  }
+
+  static createId(value = "") {
+    const cleaned = value
+      .toString()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 32);
+    if (cleaned) return cleaned;
+    if (typeof crypto !== "undefined" && crypto.randomUUID) {
+      return crypto.randomUUID();
+    }
+    return `id-${Math.random().toString(36).slice(2, 10)}`;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,325 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CallTime Desk</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="app">
+      <header class="topbar">
+        <div class="branding">
+          <span class="branding__logo" aria-hidden="true">☎︎</span>
+          <div>
+            <div class="branding__title">CallTime Desk</div>
+            <div class="branding__subtitle">Campaign call-time workspace</div>
+          </div>
+        </div>
+        <div class="topbar__actions">
+          <button class="btn btn--ghost" id="load-demo">
+            Load demo workspace
+          </button>
+          <button class="btn btn--ghost" id="open-database">
+            Donor database
+          </button>
+          <button class="btn" id="manage-clients">Manage clients</button>
+        </div>
+      </header>
+
+      <div class="layout">
+        <aside class="sidebar" aria-label="Client selector">
+          <div class="sidebar__header">
+            <h2>Clients</h2>
+            <button class="icon-btn" id="add-client" aria-label="Add client">
+              <span aria-hidden="true">＋</span>
+            </button>
+          </div>
+          <p class="sidebar__hint">Switch between campaigns with isolated notes.</p>
+          <ul class="client-list" id="client-list" role="list"></ul>
+        </aside>
+
+        <main class="workspace" id="workspace" tabindex="-1">
+          <section class="empty-state" id="empty-state">
+            <h1>Set up your first client</h1>
+            <p>
+              Connect a Google Sheet or upload donor data to create a dedicated
+              call-time desk for each campaign. Notes and outcomes are stored
+              locally and kept separate per client.
+            </p>
+            <div class="empty-state__actions">
+              <button class="btn btn--primary" id="empty-create">Add client</button>
+              <button class="btn btn--ghost" id="empty-demo">Preview demo</button>
+            </div>
+          </section>
+
+          <section class="client-dashboard hidden" id="client-dashboard">
+            <header class="client-dashboard__header">
+              <div>
+                <h1 id="client-name">Client Name</h1>
+                <p id="client-meta" class="muted"></p>
+              </div>
+              <div class="session-controls">
+                <button class="btn" id="refresh-donors">Refresh sheet</button>
+                <button class="btn btn--primary" id="start-session">
+                  Start call time
+                </button>
+                <button class="btn btn--ghost" id="manage-donors">
+                  Manage donor records
+                </button>
+              </div>
+            </header>
+
+            <div class="workspace__body">
+              <section class="donor-list" aria-labelledby="donor-list-title">
+                <div class="donor-list__header">
+                  <h2 id="donor-list-title">Donor queue</h2>
+                  <div class="donor-list__filters">
+                    <label class="sr-only" for="donor-search">Search donors</label>
+                    <input
+                      id="donor-search"
+                      class="input"
+                      type="search"
+                      placeholder="Search name, city, employer"
+                    />
+                    <label class="sr-only" for="status-filter">Filter by status</label>
+                    <select id="status-filter" class="input select">
+                      <option value="all">All outcomes</option>
+                    </select>
+                  </div>
+                </div>
+                <ul class="donor-items" id="donor-items" role="list"></ul>
+              </section>
+
+              <section class="donor-detail" aria-live="polite" id="donor-detail">
+                <div class="donor-detail__placeholder">
+                  Select a donor to review their profile and log call notes.
+                </div>
+              </section>
+            </div>
+          </section>
+        </main>
+      </div>
+    </div>
+
+    <dialog class="modal" id="client-dialog">
+      <form method="dialog" class="modal__content" id="client-form">
+        <header class="modal__header">
+          <h2 id="client-form-title">New client</h2>
+        </header>
+        <div class="modal__body">
+          <div class="form-row">
+            <label class="form-label" for="client-label">Client label</label>
+            <input
+              class="input"
+              id="client-label"
+              name="label"
+              placeholder="Jane for City Council"
+              required
+            />
+          </div>
+          <div class="form-row">
+            <label class="form-label" for="client-candidate">Candidate name</label>
+            <input
+              class="input"
+              id="client-candidate"
+              name="candidate"
+              placeholder="Jane Candidate"
+            />
+          </div>
+          <div class="form-row">
+            <label class="form-label" for="client-office">Office or race</label>
+            <input
+              class="input"
+              id="client-office"
+              name="office"
+              placeholder="City Council At-Large"
+            />
+          </div>
+          <div class="form-row">
+            <label class="form-label" for="client-sheet"
+              >Google Sheet link (publish to web)</label
+            >
+            <input
+              class="input"
+              id="client-sheet"
+              name="sheet"
+              type="url"
+              placeholder="https://docs.google.com/spreadsheets/d/.../gviz/tq?tqx=out:json"
+            />
+            <p class="form-help">
+              Paste the <strong>gviz JSON</strong> or <strong>published CSV</strong>
+              link. Each row becomes a donor record.
+            </p>
+          </div>
+          <div class="form-row">
+            <label class="form-label" for="client-timezone">Timezone</label>
+            <input
+              class="input"
+              id="client-timezone"
+              name="timezone"
+              placeholder="America/New_York"
+            />
+            <p class="form-help">
+              Used for scheduling reminders. Defaults to your browser timezone.
+            </p>
+          </div>
+        </div>
+        <footer class="modal__footer">
+          <button class="btn btn--ghost" value="cancel">Cancel</button>
+          <button class="btn btn--primary" value="confirm" id="save-client">
+            Save client
+          </button>
+        </footer>
+      </form>
+    </dialog>
+
+    <dialog class="modal modal--wide" id="donor-database">
+      <div class="modal__content modal__content--wide">
+        <header class="modal__header">
+          <h2>Donor database</h2>
+          <div class="modal__header-actions">
+            <button class="btn btn--ghost" id="export-donor-data" type="button">
+              Export JSON
+            </button>
+            <button class="icon-btn" id="close-donor-database" type="button" aria-label="Close donor database">
+              ×
+            </button>
+          </div>
+        </header>
+        <div class="modal__body database-panel">
+          <aside class="database-panel__list" aria-label="Donor records">
+            <div class="database-panel__list-header">
+              <div>
+                <h3 id="database-client-name">Client donors</h3>
+                <p class="muted" id="database-client-meta"></p>
+              </div>
+              <button class="btn btn--primary" id="add-donor" type="button">New donor</button>
+            </div>
+            <label class="sr-only" for="donor-database-search">Search donors</label>
+            <input
+              class="input"
+              id="donor-database-search"
+              type="search"
+              placeholder="Search donors"
+            />
+            <ul class="database-panel__items" id="donor-database-items" role="list"></ul>
+          </aside>
+          <section class="database-panel__editor" aria-live="polite">
+            <form id="donor-form" class="donor-form" autocomplete="off">
+              <fieldset class="form-grid">
+                <legend class="sr-only">Identity</legend>
+                <div class="form-row">
+                  <label class="form-label" for="donor-first-name">First name</label>
+                  <input class="input" id="donor-first-name" name="firstName" required />
+                </div>
+                <div class="form-row">
+                  <label class="form-label" for="donor-last-name">Last name</label>
+                  <input class="input" id="donor-last-name" name="lastName" required />
+                </div>
+                <div class="form-row">
+                  <label class="form-label" for="donor-email">Email</label>
+                  <input class="input" id="donor-email" name="email" type="email" placeholder="name@example.com" />
+                </div>
+                <div class="form-row">
+                  <label class="form-label" for="donor-phone">Phone</label>
+                  <input class="input" id="donor-phone" name="phone" placeholder="(555) 123-4567" />
+                </div>
+              </fieldset>
+
+              <fieldset class="form-grid">
+                <legend class="sr-only">Professional details</legend>
+                <div class="form-row">
+                  <label class="form-label" for="donor-company">Company</label>
+                  <input class="input" id="donor-company" name="company" />
+                </div>
+                <div class="form-row">
+                  <label class="form-label" for="donor-industry">Industry</label>
+                  <input class="input" id="donor-industry" name="industry" />
+                </div>
+                <div class="form-row">
+                  <label class="form-label" for="donor-city">City</label>
+                  <input class="input" id="donor-city" name="city" />
+                </div>
+                <div class="form-row">
+                  <label class="form-label" for="donor-tags">Tags</label>
+                  <input class="input" id="donor-tags" name="tags" placeholder="High Priority, Warm" />
+                </div>
+              </fieldset>
+
+              <fieldset class="form-grid">
+                <legend class="sr-only">Background</legend>
+                <div class="form-row">
+                  <label class="form-label" for="donor-picture">Picture URL</label>
+                  <input class="input" id="donor-picture" name="pictureUrl" type="url" placeholder="https://…" />
+                </div>
+                <div class="form-row">
+                  <label class="form-label" for="donor-ask">Suggested ask</label>
+                  <input class="input" id="donor-ask" name="ask" type="number" min="0" step="25" />
+                </div>
+                <div class="form-row">
+                  <label class="form-label" for="donor-last-gift">Last gift note</label>
+                  <input class="input" id="donor-last-gift" name="lastGift" placeholder="$1,000 (2023)" />
+                </div>
+                <div class="form-row">
+                  <label class="form-label" for="donor-notes">Internal notes</label>
+                  <input class="input" id="donor-notes" name="notes" />
+                </div>
+              </fieldset>
+
+              <div class="form-row">
+                <label class="form-label" for="donor-biography">Biography</label>
+                <textarea class="input textarea" id="donor-biography" name="biography" rows="4"></textarea>
+              </div>
+
+              <section class="donor-history-editor" aria-labelledby="history-heading">
+                <header class="donor-history-editor__header">
+                  <div>
+                    <h3 id="history-heading">Donor history</h3>
+                    <p class="muted">Add election cycles and contribution amounts.</p>
+                  </div>
+                  <div class="history-add">
+                    <label class="sr-only" for="history-year">Election year</label>
+                    <input class="input" id="history-year" name="historyYear" type="number" min="1900" max="2100" placeholder="2024" />
+                    <label class="sr-only" for="history-candidate">Candidate</label>
+                    <input class="input" id="history-candidate" name="historyCandidate" placeholder="Candidate name" />
+                    <label class="sr-only" for="history-amount">Amount</label>
+                    <input class="input" id="history-amount" name="historyAmount" type="number" min="0" step="25" placeholder="500" />
+                    <button class="btn" type="button" id="add-history-entry">Add entry</button>
+                  </div>
+                </header>
+                <div id="history-list" class="history-groups"></div>
+              </section>
+
+              <footer class="modal__footer donor-form__footer">
+                <button class="btn btn--ghost" type="button" id="delete-donor">Delete donor</button>
+                <div class="donor-form__actions">
+                  <span class="muted" id="donor-updated"></span>
+                  <button class="btn btn--primary" type="submit">Save donor</button>
+                </div>
+              </footer>
+            </form>
+            <div class="donor-form__placeholder" id="donor-placeholder">
+              <h3>Select or create a donor</h3>
+              <p>Choose a donor from the list to begin editing their profile.</p>
+            </div>
+          </section>
+        </div>
+      </div>
+    </dialog>
+
+    <template id="donor-item-template">
+      <li class="donor-item">
+        <button type="button" class="donor-item__button"></button>
+      </li>
+    </template>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,1122 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0d1017;
+  --surface: #161b22;
+  --surface-elevated: #1f2530;
+  --surface-subtle: #242b38;
+  --border: rgba(148, 163, 184, 0.24);
+  --border-strong: rgba(148, 163, 184, 0.36);
+  --text: #f8fafc;
+  --muted: #cbd5f5;
+  --muted-strong: #94a3b8;
+  --primary: #4f46e5;
+  --primary-strong: #4338ca;
+  --success: #10b981;
+  --warning: #f59e0b;
+  --danger: #ef4444;
+  --radius-lg: 20px;
+  --radius-md: 12px;
+  --radius-sm: 8px;
+  --shadow: 0 18px 40px rgba(15, 23, 42, 0.45);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  line-height: 1.5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(120% 120% at 10% 0%, #1d2533 0%, #080b10 62%);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(160% 160% at 90% 10%, #334155 0%, transparent 55%);
+  pointer-events: none;
+  opacity: 0.8;
+}
+
+.app {
+  position: relative;
+  isolation: isolate;
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2.5rem clamp(1.5rem, 5vw, 3rem) 4rem;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem clamp(1.25rem, 4vw, 2.5rem);
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+  margin-bottom: 1.75rem;
+}
+
+.branding {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.branding__logo {
+  width: 3.25rem;
+  height: 3.25rem;
+  display: grid;
+  place-items: center;
+  font-size: 1.9rem;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.2), transparent 55%);
+  border: 1px solid rgba(99, 102, 241, 0.45);
+}
+
+.branding__title {
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.branding__subtitle {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.topbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  gap: 1.5rem;
+}
+
+.sidebar {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.sidebar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.sidebar__header h2 {
+  font-size: 1.2rem;
+  margin: 0;
+}
+
+.sidebar__hint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.client-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.client-item {
+  display: flex;
+  background: rgba(36, 45, 64, 0.6);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  transition: border-color 0.25s, transform 0.25s;
+}
+
+.client-item--active {
+  border-color: rgba(99, 102, 241, 0.9);
+  transform: translateY(-1px);
+}
+
+.client-item__button {
+  flex: 1;
+  padding: 0.85rem 1rem;
+  background: transparent;
+  color: inherit;
+  border: none;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.client-item__title {
+  font-weight: 600;
+}
+
+.client-item__meta {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.client-item__actions {
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.client-item__actions button {
+  width: 44px;
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+
+.client-item__actions button:hover,
+.client-item__actions button:focus-visible {
+  background: rgba(99, 102, 241, 0.08);
+  color: var(--text);
+}
+
+.workspace {
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  min-height: 540px;
+  padding: 2rem clamp(1.5rem, 2.5vw, 2.5rem);
+  box-shadow: var(--shadow);
+}
+
+.empty-state {
+  text-align: center;
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+}
+
+.empty-state h1 {
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  margin-bottom: 0.75rem;
+}
+
+.empty-state p {
+  color: var(--muted);
+  margin-bottom: 1.5rem;
+}
+
+.empty-state__actions {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.client-dashboard__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+  margin-bottom: 1.75rem;
+}
+
+.client-dashboard__header h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 2.8vw, 2.3rem);
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.session-controls {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.workspace__body {
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+  gap: 1.5rem;
+  min-height: 420px;
+}
+
+.donor-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.donor-list__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.donor-list__header h2 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.donor-list__filters {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.input {
+  font: inherit;
+  color: inherit;
+  background: rgba(24, 32, 47, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: var(--radius-sm);
+  padding: 0.65rem 0.75rem;
+  min-width: 0;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.input:focus {
+  outline: none;
+  border-color: rgba(99, 102, 241, 0.65);
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.25);
+}
+
+.select {
+  padding-right: 2rem;
+}
+
+.donor-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 520px;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.donor-item {
+  border-radius: var(--radius-md);
+  background: rgba(36, 45, 64, 0.64);
+  border: 1px solid transparent;
+}
+
+.donor-item--active {
+  border-color: rgba(99, 102, 241, 0.75);
+  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.25);
+}
+
+.donor-item__button {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  padding: 0.9rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  cursor: pointer;
+}
+
+.donor-item__title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.donor-item__name {
+  font-weight: 600;
+}
+
+.status-pill {
+  font-size: 0.78rem;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.status-pill[data-variant="open"] {
+  background: rgba(79, 70, 229, 0.15);
+  border-color: rgba(99, 102, 241, 0.4);
+  color: #c7d2fe;
+}
+
+.status-pill[data-variant="waiting"] {
+  background: rgba(245, 158, 11, 0.15);
+  border-color: rgba(245, 158, 11, 0.3);
+  color: #fde68a;
+}
+
+.status-pill[data-variant="won"] {
+  background: rgba(16, 185, 129, 0.18);
+  border-color: rgba(16, 185, 129, 0.32);
+  color: #bbf7d0;
+}
+
+.status-pill[data-variant="closed"] {
+  background: rgba(15, 23, 42, 0.5);
+  border-color: rgba(148, 163, 184, 0.25);
+  color: var(--muted);
+}
+
+.donor-item__meta {
+  color: var(--muted);
+  font-size: 0.85rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.25rem;
+}
+
+.donor-detail {
+  background: rgba(12, 17, 26, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: var(--radius-lg);
+  padding: 1.75rem clamp(1.25rem, 2vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-height: 520px;
+}
+
+.donor-detail__placeholder {
+  color: var(--muted);
+  text-align: center;
+  margin: auto;
+  max-width: 320px;
+}
+
+.donor-detail__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.donor-detail__headline {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.donor-detail__header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.donor-detail__identity {
+  color: var(--muted);
+  margin-top: 0.35rem;
+}
+
+.donor-photo {
+  width: 96px;
+  height: 96px;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.donor-photo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.donor-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.donor-tag {
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(67, 56, 202, 0.35);
+  color: #e0e7ff;
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.donor-nav {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.donor-nav button {
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-sm);
+}
+
+.donor-contact {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.85rem;
+}
+
+.contact-card {
+  background: rgba(30, 41, 59, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: var(--radius-md);
+  padding: 0.75rem 0.9rem;
+}
+
+.contact-card__label {
+  display: block;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted-strong);
+  margin-bottom: 0.35rem;
+}
+
+.contact-card__value {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 500;
+}
+
+.contact-card__value a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.contact-card__value button {
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.donor-bio {
+  background: rgba(30, 41, 59, 0.65);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  color: var(--muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  max-height: 160px;
+  overflow-y: auto;
+}
+
+.donor-history {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.donor-history__title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.donor-history__group {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: var(--radius-md);
+  padding: 0.75rem 0.9rem;
+  background: rgba(30, 41, 59, 0.45);
+}
+
+.donor-history__group header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.35rem;
+}
+
+.donor-history__group h4 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.donor-history__count {
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
+.donor-history__group ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.donor-history__group li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.donor-history__candidate {
+  font-weight: 500;
+}
+
+.donor-history__amount {
+  font-variant-numeric: tabular-nums;
+  color: var(--muted);
+}
+
+.donor-actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  align-items: start;
+}
+
+.quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.quick-action {
+  border-radius: var(--radius-sm);
+  padding: 0.55rem 0.75rem;
+  font-size: 0.9rem;
+  border: 1px solid rgba(79, 70, 229, 0.25);
+  background: rgba(79, 70, 229, 0.15);
+  color: #c7d2fe;
+  cursor: pointer;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.quick-action:hover,
+.quick-action:focus-visible {
+  border-color: rgba(79, 70, 229, 0.55);
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.18);
+}
+
+.interaction-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.dynamic-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.form-label {
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.form-help {
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+.textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.interaction-save {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.timestamp {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.modal {
+  border: none;
+  border-radius: var(--radius-lg);
+  padding: 0;
+  background: transparent;
+  color: inherit;
+}
+
+.modal::backdrop {
+  background: rgba(15, 23, 42, 0.7);
+  backdrop-filter: blur(6px);
+}
+
+.modal__content {
+  background: rgba(13, 18, 28, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: var(--radius-lg);
+  padding: 1.75rem;
+  width: min(540px, calc(100vw - 3rem));
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.modal__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.modal__header h2 {
+  margin: 0;
+}
+
+.modal__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.modal--wide {
+  max-width: none;
+}
+
+.modal__content--wide {
+  width: min(980px, calc(100vw - 3rem));
+  max-height: min(90vh, 780px);
+  overflow: hidden;
+}
+
+.modal--wide .modal__body {
+  height: 100%;
+}
+
+.modal__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+}
+
+.database-panel {
+  display: flex;
+  gap: 1.5rem;
+  height: 100%;
+}
+
+.database-panel__list {
+  flex: 0 0 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border-right: 1px solid rgba(148, 163, 184, 0.2);
+  padding-right: 1.25rem;
+  max-height: calc(90vh - 220px);
+}
+
+.database-panel__list-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.database-panel__items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+
+.database-panel__item {
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: rgba(30, 41, 59, 0.5);
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.database-panel__item button {
+  width: 100%;
+  border: none;
+  background: none;
+  color: inherit;
+  text-align: left;
+  padding: 0.75rem 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  cursor: pointer;
+}
+
+.database-panel__item button:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+
+.database-panel__item:hover,
+.database-panel__item:focus-within {
+  border-color: rgba(99, 102, 241, 0.45);
+  background: rgba(67, 56, 202, 0.28);
+}
+
+.database-panel__item--active {
+  border-color: rgba(129, 140, 248, 0.85);
+  background: rgba(67, 56, 202, 0.4);
+}
+
+.database-panel__item-title {
+  font-weight: 600;
+}
+
+.database-panel__item-meta {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.database-panel__editor {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+}
+
+.donor-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  height: 100%;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+
+.donor-form.hidden {
+  display: none;
+}
+
+.donor-form__placeholder {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  background: linear-gradient(160deg, rgba(30, 41, 59, 0.45), rgba(15, 23, 42, 0.75));
+  border: 1px dashed rgba(148, 163, 184, 0.3);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  pointer-events: none;
+}
+
+.donor-form__placeholder.hidden {
+  display: none;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.4);
+}
+
+.donor-history-editor {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.donor-history-editor__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.history-add {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.history-add input[name="historyCandidate"] {
+  flex: 1 1 200px;
+}
+
+.history-add input[name="historyYear"],
+.history-add input[name="historyAmount"] {
+  width: 120px;
+}
+
+.history-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.history-group {
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 0.75rem;
+  background: rgba(30, 41, 59, 0.35);
+}
+
+.history-group__title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.history-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.history-table th,
+.history-table td {
+  padding: 0.4rem 0.25rem;
+  text-align: left;
+}
+
+.history-table__actions {
+  text-align: right;
+  width: 80px;
+}
+
+.history-table tbody tr:nth-child(even) {
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.history-delete {
+  border: none;
+  background: transparent;
+  color: rgba(248, 113, 113, 0.9);
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.donor-form__footer {
+  justify-content: space-between;
+  align-items: center;
+}
+
+.donor-form__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.history-empty {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+@media (max-width: 960px) {
+  .modal__content--wide {
+    width: calc(100vw - 2rem);
+  }
+
+  .database-panel {
+    flex-direction: column;
+  }
+
+  .database-panel__list {
+    flex: none;
+    border-right: none;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+    padding-right: 0;
+    padding-bottom: 1rem;
+    max-height: none;
+  }
+
+  .database-panel__editor {
+    min-height: 320px;
+  }
+}
+
+.btn {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: var(--radius-sm);
+  background: rgba(36, 45, 64, 0.75);
+  color: inherit;
+  font: inherit;
+  padding: 0.6rem 1rem;
+  cursor: pointer;
+  transition: border-color 0.2s, transform 0.2s, box-shadow 0.2s;
+}
+
+.btn:hover,
+.btn:focus-visible {
+  border-color: rgba(99, 102, 241, 0.65);
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.18);
+}
+
+.btn--primary {
+  border-color: rgba(79, 70, 229, 0.65);
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.88), rgba(129, 140, 248, 0.85));
+  color: #eef2ff;
+  font-weight: 600;
+}
+
+.btn--primary:hover,
+.btn--primary:focus-visible {
+  border-color: rgba(129, 140, 248, 0.95);
+  box-shadow: 0 12px 25px rgba(79, 70, 229, 0.35);
+  transform: translateY(-1px);
+}
+
+.btn--ghost {
+  background: transparent;
+}
+
+.icon-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: transparent;
+  color: inherit;
+  font-size: 1.2rem;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+}
+
+.icon-btn:hover,
+.icon-btn:focus-visible {
+  border-color: rgba(99, 102, 241, 0.6);
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.18);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 1080px) {
+  .layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .sidebar {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .sidebar__hint {
+    width: 100%;
+  }
+
+  .workspace {
+    padding: 1.5rem;
+  }
+
+  .workspace__body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .donor-items {
+    max-height: none;
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    background: #0f172a;
+  }
+
+  .app {
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  .topbar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .topbar__actions {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .layout {
+    gap: 1rem;
+  }
+
+  .session-controls {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .donor-list__filters {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .donor-contact {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a local CallTime database module for storing clients and donor records in the browser
- add a donor database management dialog with full profile editing, giving history entry, and JSON export per client
- surface donor photos, tags, and structured contribution history in the call-time workspace and update documentation for the new workflow

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e4427a2b3c832393ff8be481e0f761