### PR TITLE
Implement shared donor database with client assignment controls

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -27,7 +27,7 @@
             Load demo workspace
           </button>
           <button class="btn btn--ghost" id="open-database">
-            Donor database
+            Complete donor database
           </button>
           <button class="btn" id="manage-clients">Manage clients</button>
         </div>
@@ -183,7 +183,7 @@
     <dialog class="modal modal--wide" id="donor-database">
       <div class="modal__content modal__content--wide">
         <header class="modal__header">
-          <h2>Donor database</h2>
+          <h2>Complete donor database</h2>
           <div class="modal__header-actions">
             <button class="btn btn--ghost" id="export-donor-data" type="button">
               Export JSON
@@ -196,8 +196,12 @@
         <div class="modal__body database-panel">
           <aside class="database-panel__list" aria-label="Donor records">
             <div class="database-panel__list-header">
-              <div>
-                <h3 id="database-client-name">Client donors</h3>
+              <div class="database-panel__list-title">
+                <h3>All donors</h3>
+                <div class="database-panel__client-picker">
+                  <label class="form-label" for="database-client-selector">Assign to focus list</label>
+                  <select class="input select" id="database-client-selector"></select>
+                </div>
                 <p class="muted" id="database-client-meta"></p>
               </div>
               <button class="btn btn--primary" id="add-donor" type="button">New donor</button>
@@ -277,6 +281,14 @@
                 <label class="form-label" for="donor-biography">Biography</label>
                 <textarea class="input textarea" id="donor-biography" name="biography" rows="4"></textarea>
               </div>
+
+              <section class="donor-access" aria-labelledby="donor-assignments-heading">
+                <div class="donor-access__header">
+                  <h3 id="donor-assignments-heading">Client access</h3>
+                  <p class="muted">Choose which campaigns can see this donor in their call queue.</p>
+                </div>
+                <div id="donor-client-assignments" class="donor-access__list"></div>
+              </section>
 
               <section class="donor-history-editor" aria-labelledby="history-heading">
                 <header class="donor-history-editor__header">

--- a/public/styles.css
+++ b/public/styles.css
@@ -762,6 +762,23 @@ body::before {
   gap: 0.75rem;
 }
 
+.database-panel__list-title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.database-panel__client-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.database-panel__client-picker .form-label {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
 .database-panel__items {
   list-style: none;
   margin: 0;
@@ -778,10 +795,14 @@ body::before {
   border-radius: var(--radius-sm);
   background: rgba(30, 41, 59, 0.5);
   transition: border-color 0.2s, background 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
 }
 
-.database-panel__item button {
-  width: 100%;
+.database-panel__select {
+  flex: 1;
   border: none;
   background: none;
   color: inherit;
@@ -793,9 +814,26 @@ body::before {
   cursor: pointer;
 }
 
-.database-panel__item button:disabled {
+.database-panel__select:disabled {
   opacity: 0.7;
   cursor: default;
+}
+
+.database-panel__item-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding-right: 0.85rem;
+}
+
+.database-panel__item-toggle label {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.database-panel__focus {
+  width: 1rem;
+  height: 1rem;
 }
 
 .database-panel__item:hover,
@@ -872,6 +910,48 @@ body::before {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.donor-access {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin: 1.5rem 0;
+}
+
+.donor-access__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.donor-access__list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.5rem;
+}
+
+.donor-access__item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border-radius: var(--radius-sm);
+  background: rgba(30, 41, 59, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.donor-access__item input {
+  width: 1rem;
+  height: 1rem;
+}
+
+.donor-access__item span {
+  font-size: 0.9rem;
 }
 
 .donor-history-editor__header {


### PR DESCRIPTION
## Summary
- introduce a shared donor store that tracks global records, client assignments, and legacy migrations
- refresh the donor database workflow with searchable global lists, focus toggles, and per-donor client access checklists
- update modal layout and styling to support the new selector, assignment UI, and messaging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e493c936708323a2312000f728727c